### PR TITLE
Decode Event Urls

### DIFF
--- a/CRM/Calendar/Page/AJAX.php
+++ b/CRM/Calendar/Page/AJAX.php
@@ -44,7 +44,7 @@ class CRM_Calendar_Page_AJAX
 
     while ($dao->fetch()) {
       if ($dao->title) {
-        $dao->url = CRM_Utils_System::url('civicrm/event/info', 'reset=1&id=' . $dao->id );
+        $dao->url = htmlspecialchars_decode(CRM_Utils_System::url('civicrm/event/info', 'reset=1&id=' . $dao->id ));
       }
 
       $eventData = array();


### PR DESCRIPTION
Currently event urls are not html decoded like the case and activity urls. This makes the urls unusable on my install (CiviCRM 4.7.22 / Joomla 3.7.5)

Let me know if there is some reason these urls are treated differently.