### PR TITLE
replaces Default Domain Name by min(id)

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -184,7 +184,7 @@ function calendar_civicrm_dashboard($contactID, &$contentPlacement)
     
     $isOnDashboard = CRM_Core_DAO::singleValueQuery("
         SELECT count(*) FROM civicrm_dashboard
-        WHERE name='calendar' and is_active=1 and domain_id in (select id from civicrm_domain where name = 'Default Domain Name')
+        WHERE name='calendar' and is_active=1 and domain_id in (select MIN(id) FROM civicrm_domain)
       ");
     if($isOnDashboard){
         _calendar_civix_addJSCss();


### PR DESCRIPTION
In calendar.php, the function calendar_civicrm_dashboard uses:
  select id from civicrm_domain where name = 'Default Domain Name'
This does not return a record because in production environments the name contains the name of the organization, not 'Default Domain Name'.




