### PR TITLE
Comment out WIP locale code

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -207,6 +207,7 @@ function _calendar_civix_addJSCss() {
     ->addScriptFile('com.agiliway.civicalendar', 'js/fullcalendar.min.js', 201, 'html-header');
   CRM_Core_Resources::singleton()
     ->addScriptFile('com.agiliway.civicalendar', 'js/locale-all.js', 201, 'html-header');
-  CRM_Core_Resources::singleton()
-    ->addScriptFile('com.agiliway.civicalendar', 'locale/' . CRM_Calendar_Settings::getValue('locale') . '.js', 202, 'html-header');
+  // WIP - add locale js files
+  // CRM_Core_Resources::singleton()
+  //   ->addScriptFile('com.agiliway.civicalendar', 'locale/' . CRM_Calendar_Settings::getValue('locale') . '.js', 202, 'html-header');
 }


### PR DESCRIPTION
I was noticing errors in the console:

> 00:05:27.368 dashboard?reset=1:104 GET http://localhost/sites/default/files/civicrm/ext/com.agiliway.civicalendar/locale/.js?r=EyF9a 403 (Forbidden)
00:05:27.800 dashboard?reset=1:104 GET http://localhost/sites/default/files/civicrm/ext/com.agiliway.civicalendar/locale/.js?r=EyF9a 403 (Forbidden)
00:05:27.800 dashboard?reset=1:1 Refused to execute script from 'http://localhost/sites/default/files/civicrm/ext/com.agiliway.civicalendar/locale/.js?r=EyF9a' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.

It looks like the idea of localized scripts is WIP and currently non-functional so I've commented it out to suppress the errors.